### PR TITLE
Simplfied AWS credential loading

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -133,8 +133,6 @@ module.exports = function(grunt) {
 
         aws_s3: {
             options: {
-                accessKeyId: '<%= visuals.aws.AWSAccessKeyID %>',
-                secretAccessKey: '<%= visuals.aws.AWSSecretKey %>',
                 region: 'us-east-1',
                 debug: grunt.option('dry'),
                 bucket: '<%= visuals.s3.bucket %>'
@@ -181,10 +179,8 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask('loadDeployConfig', function() {
-        if (!grunt.file.exists('cfg/aws-keys.json')) grunt.fail.fatal('./cfg/aws-keys.json missing');
         grunt.config('visuals', {
             s3: grunt.file.readJSON('./cfg/s3.json'),
-            aws: grunt.file.readJSON('./cfg/aws-keys.json'),
             timestamp: Date.now(),
             jspmFlags: '-m',
             assetPath: '<%= visuals.s3.domain %><%= visuals.s3.path %>/<%= visuals.timestamp %>'

--- a/README.md
+++ b/README.md
@@ -16,8 +16,19 @@ Development
 
 Production / deployment
 -----------------------
-1. Update `cfg/s3.json` and create `aws-keys.json` (copy from `aws-keys.example.json`)
-1. `grunt deploy`
+
+1. Update `cfg/s3.json`
+2. `grunt deploy`
+
+NOTE: Ensure you have AWS credentials setup by either adding them to your `~/.bashrc` or
+creating a `~/.aws/credentials` file with the following content:
+
+```
+[default]
+aws_access_key_id = <YOUR_ACCESS_KEY_ID>
+aws_secret_access_key = <YOUR_SECRET_ACCESS_KEY>
+```
+
 
 Using third party js
 --------------------

--- a/cfg/aws-keys.example.json
+++ b/cfg/aws-keys.example.json
@@ -1,4 +1,0 @@
-{
-	"AWSAccessKeyID": "AKxxxxxxxxxx",
-	"AWSSecretKey": "super-secret-key"
-}


### PR DESCRIPTION
Removed the need for a aws config file. Credentials will now be loaded from ENV values or the amazon approved ~/.aws/credentials file.